### PR TITLE
Update utils.c

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -428,6 +428,7 @@ int match_string(const char *string, const char *pattern)
 	}
 
 	status = regexec(&regex, string, 0, NULL, 0);
+	regfree(&regex);
 	if (status != 0)
 		return 0;
 


### PR DESCRIPTION
On CentOS 7 ledmon leaks memory pretty badly when there is Adaptec RAID controller present. It seems this simple patch deals with the matter.